### PR TITLE
feat(test): integration tests for config and custom provider merging

### DIFF
--- a/docs/bmm-workflow-status.yaml
+++ b/docs/bmm-workflow-status.yaml
@@ -8,7 +8,7 @@ project_type: 'cli'
 project_level: 0
 communication_language: 'English'
 output_language: 'English'
-last_updated: '2026-04-14T12:00:00Z'
+last_updated: '2026-04-14T12:30:00Z'
 
 # Workflow Status Tracking
 workflow_status:
@@ -373,3 +373,9 @@ workflow_status:
     status: 'docs/stories/STORY-024-integration-tests-config-custom-provider.md'
     description: 'Integration tests for config file loading and custom provider merging'
     command: '/create-story'
+
+  - name: dev-story-024
+    phase: 4
+    status: 'completed'
+    description: 'Implement STORY-024: Integration tests for config and custom providers'
+    command: '/dev-story'

--- a/docs/stories/STORY-024-inconsistency-report.md
+++ b/docs/stories/STORY-024-inconsistency-report.md
@@ -1,0 +1,89 @@
+# Branch Inconsistency Report: feat-STORY-024-integration-tests-config-custom-provider
+
+**Generated:** 2026-04-14
+**Branch:** `feat-STORY-024-integration-tests-config-custom-provider`
+
+---
+
+## 1. Implemented Stories Still Marked as "Not Started"
+
+Several stories that were implemented in earlier commits on this branch still have their markdown story files marked with `status: Not Started`, while `docs/bmm-workflow-status.yaml` correctly marks their `dev-story-*` entries as `completed`. This creates a source-of-truth conflict between the story files and the workflow tracker.
+
+### Affected Stories
+
+| Story ID  | Story Title                                   | Commit That Implemented It                                | Story File Status | Workflow Status |
+| --------- | --------------------------------------------- | --------------------------------------------------------- | ----------------- | --------------- |
+| STORY-015 | Dependency Injection Refactor for Testability | `5dd532c` refactor(generate): add dependency injection    | **Not Started**   | `completed`     |
+| STORY-016 | Integration Testing Framework with ts-mockito | `639e48d` feat(test): add integration testing framework   | **Not Started**   | `completed`     |
+| STORY-019 | Integration Tests for commit Command          | `3405ac1` feat(test): add integration tests for commit... | **Not Started**   | `completed`     |
+| STORY-020 | Integration Tests for model Command           | `3405ac1` (same)                                          | **Not Started**   | `completed`     |
+| STORY-021 | Integration Tests for status Command          | `3405ac1` (same)                                          | **Not Started**   | `completed`     |
+| STORY-022 | Integration Tests for version Command         | `3405ac1` (same)                                          | **Not Started**   | `completed`     |
+
+### Recommended Action
+
+Update the frontmatter in each affected story markdown file to `status: Completed` so the BMAD workflow tracker and story documents are consistent.
+
+---
+
+## 2. Result-Pattern Migration Stories (011–013) Are Partially Implemented
+
+Commit `4da499b` on this branch (`refactor: migrate from custom result.ts to typescript-result package`) introduced the `typescript-result` package and refactored **newly implemented features** (e.g., `src/config.ts`, `src/cmd/model.ts`) to use it. However, the Result pattern migration for **existing code that predates the stories** (e.g., `src/models-dev.ts`, `src/ai.ts`, `src/git.ts`, and command handlers) remains pending.
+
+Because of this partial state:
+
+- `dev-story-011`, `dev-story-012`, and `dev-story-013` are marked `not-started` in `docs/bmm-workflow-status.yaml`
+- The story markdown files (`STORY-011-result-pattern-models-dev.md`, `STORY-012-result-pattern-ai.md`, `STORY-013-result-pattern-git-cmd.md`) have **no `status` frontmatter field at all**
+
+### Recommended Action
+
+Keep the `dev-story-*` entries as `not-started` until the existing pre-story code is fully migrated to the `typescript-result` pattern. Optionally add `status: In Progress` to the story markdown files to reflect the partial adoption.
+
+---
+
+## 3. Sprint Status Tracker Is Completely Stale
+
+`docs/stories/sprint-status.yaml` has not been updated to reflect the current project state:
+
+- It claims **Sprint 1** is `active`
+- It lists all 6 Sprint 1 stories as `not_started`
+- In reality, Sprint 1 and Sprint 2 are effectively complete, and the branch is currently executing **Sprint 3** stories (STORY-023 and STORY-024)
+
+This file was never updated when commit `d50301e` introduced the Sprint 3 plan.
+
+### Recommended Action
+
+Update `sprint-status.yaml` to:
+
+- Set `sprint: 3`
+- Update `status: active`
+- Update `sprint_plan: 'docs/stories/sprint-3-plan.md'`
+- Refresh the `stories` list to reflect Sprint 3 contents
+
+---
+
+## 4. Asymmetric Sprint 3 Workflow Entries
+
+In `docs/bmm-workflow-status.yaml`, Sprint 3 has `create-story-023`, `create-story-024`, and `dev-story-024`, but there is **no `dev-story-023` entry**. Sprints 1 and 2 maintain a consistent pattern of pairing every `create-story-*` with a corresponding `dev-story-*` entry, even before implementation begins.
+
+### Recommended Action
+
+Add a `dev-story-023` entry to `docs/bmm-workflow-status.yaml` with `status: not-started` to maintain structural symmetry and make the Sprint 3 plan complete.
+
+---
+
+## Summary of Files Requiring Updates
+
+| File                                                          | What Needs Updating                        |
+| ------------------------------------------------------------- | ------------------------------------------ |
+| `docs/stories/STORY-015-dependency-injection-refactor.md`     | Change `status: Not Started` → `Completed` |
+| `docs/stories/STORY-016-integration-testing-ts-mockito.md`    | Change `status: Not Started` → `Completed` |
+| `docs/stories/STORY-019-integration-tests-commit-command.md`  | Change `status: Not Started` → `Completed` |
+| `docs/stories/STORY-020-integration-tests-model-command.md`   | Change `status: Not Started` → `Completed` |
+| `docs/stories/STORY-021-integration-tests-status-command.md`  | Change `status: Not Started` → `Completed` |
+| `docs/stories/STORY-022-integration-tests-version-command.md` | Change `status: Not Started` → `Completed` |
+| `docs/stories/sprint-status.yaml`                             | Update to Sprint 3                         |
+| `docs/bmm-workflow-status.yaml`                               | Add `dev-story-023` entry                  |
+| `docs/stories/STORY-011-result-pattern-models-dev.md`         | Add `status` frontmatter                   |
+| `docs/stories/STORY-012-result-pattern-ai.md`                 | Add `status` frontmatter                   |
+| `docs/stories/STORY-013-result-pattern-git-cmd.md`            | Add `status` frontmatter                   |

--- a/docs/stories/STORY-024-integration-tests-config-custom-provider.md
+++ b/docs/stories/STORY-024-integration-tests-config-custom-provider.md
@@ -2,7 +2,7 @@
 story_id: STORY-024
 title: Integration tests for config file loading and custom provider merging
 created_at: 2026-04-14
-status: Not Started
+status: Completed
 sprint: Sprint 3
 epic: Epic 2 - Config Integration Tests
 ---

--- a/src/config.ts
+++ b/src/config.ts
@@ -5,16 +5,16 @@ import { Result } from 'typescript-result';
 const DEFAULT_MAX_TOKENS = 200;
 const DEFAULT_TEMPERATURE = 0.3;
 
-export async function loadConfig(): Promise<Result<ConfigFile, Error>> {
-  const configPath = getConfigFile();
+export async function loadConfig(configPath?: string): Promise<Result<ConfigFile, Error>> {
+  const path = configPath ?? getConfigFile();
 
   try {
-    const fileContent = await Deno.readTextFile(configPath);
+    const fileContent = await Deno.readTextFile(path);
 
     try {
       const configFile = JSON.parse(fileContent) as ConfigFile;
 
-      if (!configFile || typeof configFile !== 'object') {
+      if (!configFile || typeof configFile !== 'object' || Array.isArray(configFile)) {
         return Result.error(new Error('Config file must be a JSON object'));
       }
 

--- a/tests/integration/config-tests/load-config.test.ts
+++ b/tests/integration/config-tests/load-config.test.ts
@@ -1,0 +1,84 @@
+import { assertEquals } from '@std/assert';
+import { loadConfig } from '../../../src/config.ts';
+
+Deno.test('loadConfig: returns empty config when file does not exist', async () => {
+  const result = await loadConfig('/nonexistent/path/config.json');
+  assertEquals(result.ok, true);
+  if (result.ok) {
+    assertEquals(result.value, {});
+  }
+});
+
+Deno.test('loadConfig: parses valid config file', async () => {
+  const tempDir = await Deno.makeTempDir();
+  const configPath = `${tempDir}/config.json`;
+  await Deno.writeTextFile(
+    configPath,
+    JSON.stringify({ model: 'gpt-4o', temperature: 0.5 }),
+  );
+
+  const result = await loadConfig(configPath);
+  assertEquals(result.ok, true);
+  if (result.ok) {
+    assertEquals(result.value.model, 'gpt-4o');
+    assertEquals(result.value.temperature, 0.5);
+  }
+
+  await Deno.remove(tempDir, { recursive: true });
+});
+
+Deno.test('loadConfig: returns error when file contains invalid JSON', async () => {
+  const tempDir = await Deno.makeTempDir();
+  const configPath = `${tempDir}/config.json`;
+  await Deno.writeTextFile(configPath, 'not valid json {[');
+
+  const result = await loadConfig(configPath);
+  assertEquals(result.ok, false);
+  if (!result.ok) {
+    assertEquals(result.error.message.includes('Failed to parse config file'), true);
+  }
+
+  await Deno.remove(tempDir, { recursive: true });
+});
+
+Deno.test('loadConfig: returns error when file is an array', async () => {
+  const tempDir = await Deno.makeTempDir();
+  const configPath = `${tempDir}/config.json`;
+  await Deno.writeTextFile(configPath, JSON.stringify([1, 2, 3]));
+
+  const result = await loadConfig(configPath);
+  assertEquals(result.ok, false);
+  if (!result.ok) {
+    assertEquals(result.error.message, 'Config file must be a JSON object');
+  }
+
+  await Deno.remove(tempDir, { recursive: true });
+});
+
+Deno.test('loadConfig: returns error when file is a string', async () => {
+  const tempDir = await Deno.makeTempDir();
+  const configPath = `${tempDir}/config.json`;
+  await Deno.writeTextFile(configPath, JSON.stringify('hello'));
+
+  const result = await loadConfig(configPath);
+  assertEquals(result.ok, false);
+  if (!result.ok) {
+    assertEquals(result.error.message, 'Config file must be a JSON object');
+  }
+
+  await Deno.remove(tempDir, { recursive: true });
+});
+
+Deno.test('loadConfig: returns error when file is a number', async () => {
+  const tempDir = await Deno.makeTempDir();
+  const configPath = `${tempDir}/config.json`;
+  await Deno.writeTextFile(configPath, JSON.stringify(42));
+
+  const result = await loadConfig(configPath);
+  assertEquals(result.ok, false);
+  if (!result.ok) {
+    assertEquals(result.error.message, 'Config file must be a JSON object');
+  }
+
+  await Deno.remove(tempDir, { recursive: true });
+});

--- a/tests/integration/config-tests/merge-config.test.ts
+++ b/tests/integration/config-tests/merge-config.test.ts
@@ -1,0 +1,112 @@
+import { assertEquals } from '@std/assert';
+import { mergeConfig } from '../../../src/config.ts';
+import type { ConfigFile, CustomProviderConfig } from '../../../src/types.ts';
+
+const DEFAULT_PROVIDERS: Record<string, CustomProviderConfig> = {
+  openai: {
+    npm: '@ai-sdk/openai',
+    env: ['OPENAI_API_KEY'],
+    models: {
+      'gpt-4o': {
+        name: 'GPT-4o',
+        reasoning: false,
+        tool_call: true,
+        attachment: true,
+        temperature: true,
+      },
+    },
+  },
+};
+
+const DEFAULT_CONFIG = {
+  model: 'default-model',
+  maxTokens: 200,
+  temperature: 0.3,
+  providers: DEFAULT_PROVIDERS,
+};
+
+Deno.test('mergeConfig: CLI options override config file values', () => {
+  const result = mergeConfig(
+    { model: 'cli-model' },
+    {},
+    { model: 'config-model' } as ConfigFile,
+    DEFAULT_CONFIG,
+  );
+  assertEquals(result.model, 'cli-model');
+});
+
+Deno.test('mergeConfig: env vars override config file values but not CLI options', () => {
+  const result = mergeConfig(
+    { model: 'cli-model' },
+    { model: 'env-model' },
+    { model: 'config-model' } as ConfigFile,
+    DEFAULT_CONFIG,
+  );
+  assertEquals(result.model, 'cli-model');
+});
+
+Deno.test('mergeConfig: env vars override config file when no CLI option', () => {
+  const result = mergeConfig(
+    {},
+    { model: 'env-model' },
+    { model: 'config-model' } as ConfigFile,
+    DEFAULT_CONFIG,
+  );
+  assertEquals(result.model, 'env-model');
+});
+
+Deno.test('mergeConfig: config file values override defaults', () => {
+  const result = mergeConfig(
+    {},
+    {},
+    { model: 'config-model', temperature: 0.7 } as ConfigFile,
+    DEFAULT_CONFIG,
+  );
+  assertEquals(result.model, 'config-model');
+  assertEquals(result.temperature, 0.7);
+  assertEquals(result.maxTokens, 200);
+});
+
+Deno.test('mergeConfig: custom providers from config file are merged into resolved config', () => {
+  const customProviders: Record<string, CustomProviderConfig> = {
+    custom: {
+      npm: '@ai-sdk/custom',
+      env: ['CUSTOM_API_KEY'],
+      models: {
+        'custom-model': {
+          name: 'Custom Model',
+          reasoning: false,
+          tool_call: false,
+          attachment: false,
+          temperature: true,
+        },
+      },
+    },
+  };
+
+  const result = mergeConfig(
+    {},
+    {},
+    { providers: customProviders } as ConfigFile,
+    DEFAULT_CONFIG,
+  );
+  assertEquals(result.providers, customProviders);
+});
+
+Deno.test('mergeConfig: custom providers from defaults are used when config file has no providers', () => {
+  const result = mergeConfig(
+    {},
+    {},
+    { model: 'config-model' } as ConfigFile,
+    DEFAULT_CONFIG,
+  );
+  assertEquals(result.providers, DEFAULT_PROVIDERS);
+});
+
+Deno.test('mergeConfig: defaults are used when no overrides provided', () => {
+  const result = mergeConfig({}, {}, {}, DEFAULT_CONFIG);
+  assertEquals(result.model, 'default-model');
+  assertEquals(result.maxTokens, 200);
+  assertEquals(result.temperature, 0.3);
+  assertEquals(result.providers, DEFAULT_PROVIDERS);
+});


### PR DESCRIPTION
## Summary

Implements STORY-024: Integration tests for config file loading and custom provider merging.

## Changes

- **src/config.ts**: Add optional `configPath` parameter to `loadConfig()` for testability, and fix array validation to reject JSON arrays.
- **tests/integration/config-tests/load-config.test.ts**: 6 integration tests for `loadConfig()`.
- **tests/integration/config-tests/merge-config.test.ts**: 7 integration tests for `mergeConfig()`.
- **docs/**: Mark STORY-024 as completed, add inconsistency report.

## Verification

- `deno test --allow-run --allow-env --allow-read --allow-write` passes (50 tests)
- `deno fmt` and `deno lint` clean
- Tests use temporary directories — no dependency on real `~/.config/git-commit-ai/`