### PR TITLE
fix(config): implement model resolution from env var and config file

### DIFF
--- a/docs/bmm-workflow-status.yaml
+++ b/docs/bmm-workflow-status.yaml
@@ -8,7 +8,7 @@ project_type: 'cli'
 project_level: 0
 communication_language: 'English'
 output_language: 'English'
-last_updated: '2026-04-14T12:30:00Z'
+last_updated: '2026-04-14T13:56:43Z'
 
 # Workflow Status Tracking
 workflow_status:
@@ -383,13 +383,13 @@ workflow_status:
   - name: create-story-025
     phase: 4
     status: 'docs/stories/STORY-025-fix-env-model-variable.md'
-    description: 'Fix GIT_COMMIT_AI_MODEL environment variable ignored'
+    description: 'Fix model resolution from env var and config file'
     command: '/create-story'
 
   - name: dev-story-025
     phase: 4
-    status: 'not-started'
-    description: 'Implement STORY-025: Fix GIT_COMMIT_AI_MODEL environment variable ignored'
+    status: 'completed'
+    description: 'Implement STORY-025: Fix model resolution from env var and config file'
     command: '/dev-story'
 
   - name: dev-story-024

--- a/docs/stories/STORY-025-fix-env-model-variable.md
+++ b/docs/stories/STORY-025-fix-env-model-variable.md
@@ -1,48 +1,59 @@
 ---
 story_id: STORY-025
-title: Fix GIT_COMMIT_AI_MODEL environment variable ignored
+title: Fix model resolution from env var and config file
 created_at: 2026-04-14
-status: Not Started
+status: Completed
 sprint: Sprint 3
 epic: Epic 1 - CLI Simplification
 ---
 
-# Story 3.3: Fix `GIT_COMMIT_AI_MODEL` environment variable being ignored
+# Story 3.3: Fix model resolution from environment variable and config file
 
 **Story ID:** STORY-025
 **Priority:** High
-**Status:** Not Started
+**Status:** Completed
 **Sprint:** Sprint 3
 **Epic:** Epic 1 — CLI Simplification
 
 ## User Story
 
-As a user, I want the `GIT_COMMIT_AI_MODEL` environment variable to work correctly so that I don't have to pass `--model` every time I run `git-commit-ai generate`.
+As a user, I want to configure the model via environment variable or config file so that I don't have to pass `--model` every time I run `git-commit-ai generate`.
 
 ## Context
 
-Passing `--model` on the CLI works fine, but setting `GIT_COMMIT_AI_MODEL` in the environment currently fails with:
+Two issues were discovered:
 
-```
-❌ Error: No model specified. Please provide a model using the --model option or set GIT_COMMIT_AI_MODEL environment variable.
-```
+1. **Env var ignored**: Setting `GIT_COMMIT_AI_MODEL` in the environment fails with:
+   ```
+   ❌ Error: No model specified. Please provide a model using the --model option or set GIT_COMMIT_AI_MODEL environment variable.
+   ```
+   The validation check `if (!options.model)` runs **before** the merged `aiConfig` is computed.
 
-This is contradictory because the user *did* set `GIT_COMMIT_AI_MODEL`.
+2. **Config file not loaded**: The `mergeConfig` function supports `configFile?.model`, but the config file is never loaded in `handleGenerate` — it passes `undefined` for the `configFile` parameter.
 
-The root cause is in `src/cmd/generate.ts`: the validation check `if (!options.model)` runs **before** the merged `aiConfig` is used. It should instead check `aiConfig.model` (which already correctly prioritizes CLI options > env vars > config file > defaults).
+## Model Resolution Priority
+
+The model value should be resolved in this priority order:
+
+1. `--model` CLI flag (highest) — explicit user intent for this run
+2. `GIT_COMMIT_AI_MODEL` environment variable — environment-specific settings
+3. `model` field in config file (`~/.config/git-commit-ai/config.json`) — persistent defaults
+4. Built-in default model (lowest)
 
 ## Acceptance Criteria
 
-- [ ] `GIT_COMMIT_AI_MODEL=provider/model git-commit-ai generate` succeeds without `--model`
-- [ ] `--model` still overrides `GIT_COMMIT_AI_MODEL` when both are provided
-- [ ] Config file `model` field still works when neither CLI option nor env var is set
-- [ ] When no model is provided via any source, the error message remains helpful
-- [ ] Existing tests pass
-- [ ] Add regression test for env-var model resolution
+- [x] `GIT_COMMIT_AI_MODEL=provider/model git-commit-ai generate` succeeds without `--model`
+- [x] `--model` CLI flag overrides `GIT_COMMIT_AI_MODEL` env var
+- [x] `--model` CLI flag overrides config file `model` field
+- [x] `GIT_COMMIT_AI_MODEL` env var overrides config file `model` field
+- [x] Config file `model` field works when neither CLI flag nor env var is set
+- [x] When no model is provided via any source, the error message remains helpful
+- [x] Existing tests pass
+- [x] Add regression tests for all model resolution paths
 
 ## Technical Design
 
-### Root Cause
+### Issue 1: Validation Before Merge
 
 In `src/cmd/generate.ts`:
 
@@ -54,44 +65,64 @@ if (!options.model) {
 }
 ```
 
-`options.model` is the raw CLI option. The merged `aiConfig` is computed *after* this check, so the env var is never consulted for validation.
+`options.model` is the raw CLI option. The merged `aiConfig` is computed _after_ this check, so env vars and config files are never consulted for validation.
 
-### Fix
-
-Move or change the validation to check `aiConfig.model`:
+### Issue 2: Config File Not Loaded
 
 ```typescript
 const aiConfig: AIConfig = mergeConfig(
   { model: options.model, temperature: options.temperature, maxTokens: options.maxTokens },
   envVars,
-  undefined,
+  undefined,  // <-- configFile is never loaded!
+  defaults,
+);
+```
+
+The `loadConfig` function exists in `src/config.ts` but is not called in `handleGenerate`.
+
+### Fix
+
+1. Import `loadConfig` from `config.ts`
+2. Load config file before computing `aiConfig`
+3. Move validation to check `aiConfig.model` after merge
+
+```typescript
+import { loadConfig, mergeConfig } from '../config.ts';
+
+// ... in handleGenerate:
+
+const configFileResult = await loadConfig();
+const configFile = configFileResult.isOk() ? configFileResult.getValue() : undefined;
+
+const aiConfig: AIConfig = mergeConfig(
+  { model: options.model, temperature: options.temperature, maxTokens: options.maxTokens },
+  envVars,
+  configFile,
   defaults,
 );
 
 if (!aiConfig.model) {
   logger.log(
     red(
-      '❌ Error: No model specified. Please provide a model using the --model option or set GIT_COMMIT_AI_MODEL environment variable.',
+      '❌ Error: No model specified. Please provide a model using the --model option, set GIT_COMMIT_AI_MODEL environment variable, or add "model" to your config file.',
     ),
   );
   exit(1);
 }
 ```
 
-Then replace all subsequent references from `options.model` to `aiConfig.model` inside `handleGenerate` where appropriate (e.g., debug logging).
-
 ### Files to Modify
 
-- `src/cmd/generate.ts` — Fix validation to use `aiConfig.model` instead of `options.model`
-- `tests/integration/generate-tests/` — Add regression test for env-var model
+- `src/cmd/generate.ts` — Load config file and fix validation to use `aiConfig.model`
+- `tests/integration/generate-tests/env-model.test.ts` — Add tests for config file model resolution
 
 ## Files to Create
 
-- None (or new test file if creating a dedicated env-var test)
+- None (tests added to existing test file)
 
 ## Story Points
 
-1
+2
 
 ## Dependencies
 

--- a/docs/stories/sprint-3-plan.md
+++ b/docs/stories/sprint-3-plan.md
@@ -63,10 +63,10 @@ Add isolated integration tests for config file loading and custom provider mergi
 
 ## Risks
 
-| Risk                             | Impact | Mitigation                                |
-| -------------------------------- | ------ | ----------------------------------------- |
-| Users depend on `commit` command | Low    | `generate --commit` is equivalent         |
-| Integration tests touch real FS  | Low    | Use temp directories in tests             |
+| Risk                             | Impact | Mitigation                        |
+| -------------------------------- | ------ | --------------------------------- |
+| Users depend on `commit` command | Low    | `generate --commit` is equivalent |
+| Integration tests touch real FS  | Low    | Use temp directories in tests     |
 
 ---
 

--- a/docs/stories/sprint-status.yaml
+++ b/docs/stories/sprint-status.yaml
@@ -5,7 +5,7 @@
 sprint: 3
 project: git-commit-ai
 project_level: 0
-status: active
+status: completed
 created: '2026-04-14'
 target_completion: '2026-05-11'
 
@@ -37,7 +37,7 @@ stories:
 
   - id: STORY-025
     name: 'Fix GIT_COMMIT_AI_MODEL environment variable ignored'
-    status: not_started
+    status: completed
     priority: high
     file: 'docs/stories/STORY-025-fix-env-model-variable.md'
 

--- a/src/cmd/generate.ts
+++ b/src/cmd/generate.ts
@@ -3,7 +3,7 @@ import { displayChangeSummary, getChangeSummary, getStagedDiff, isGitRepository 
 import { Confirm, Input } from '@cliffy/prompt';
 import type { AIConfig, ChangeSummary, CustomProviderConfig } from '../types.ts';
 import { blue, bold, cyan, green, red, yellow } from '@std/fmt/colors';
-import { mergeConfig } from '../config.ts';
+import { loadConfig, mergeConfig } from '../config.ts';
 import { ENV } from '../cli.ts';
 
 export class ProcessExitError extends Error {
@@ -137,22 +137,6 @@ export async function handleGenerate(
 
     displayChangeSummary(changeSummary);
 
-    if (options.debug) {
-      logger.log(yellow('Debug: Git diff preview:'));
-      logger.log(yellow(diff.substring(0, 500) + '...'));
-      logger.log(yellow(`Debug: Using model: ${options.model}`));
-      logger.log();
-    }
-
-    if (!options.model) {
-      logger.log(
-        red(
-          '❌ Error: No model specified. Please provide a model using the --model option or set GIT_COMMIT_AI_MODEL environment variable.',
-        ),
-      );
-      exit(1);
-    }
-
     const envVars = {
       model: Deno.env.get('GIT_COMMIT_AI_MODEL'),
       temperature: Deno.env.get('GIT_COMMIT_AI_TEMPERATURE')
@@ -172,12 +156,31 @@ export async function handleGenerate(
       providers: ENV.providers as Record<string, CustomProviderConfig>,
     };
 
+    const configFileResult = await loadConfig();
+    const configFile = configFileResult.ok ? configFileResult.value : undefined;
+
     const aiConfig: AIConfig = mergeConfig(
       { model: options.model, temperature: options.temperature, maxTokens: options.maxTokens },
       envVars,
-      undefined,
+      configFile,
       defaults,
     );
+
+    if (options.debug) {
+      logger.log(yellow('Debug: Git diff preview:'));
+      logger.log(yellow(diff.substring(0, 500) + '...'));
+      logger.log(yellow(`Debug: Using model: ${aiConfig.model}`));
+      logger.log();
+    }
+
+    if (!aiConfig.model) {
+      logger.log(
+        red(
+          '❌ Error: No model specified. Please provide a model using the --model option, set GIT_COMMIT_AI_MODEL environment variable, or add "model" to your config file.',
+        ),
+      );
+      exit(1);
+    }
 
     let commitMessage = '';
     try {

--- a/tests/integration/generate-tests/env-model.test.ts
+++ b/tests/integration/generate-tests/env-model.test.ts
@@ -1,0 +1,196 @@
+import { assertEquals } from '@std/assert';
+import { capture } from 'ts-mockito';
+import { createHarness } from '../helpers/test-harness.ts';
+
+// Helper to create a temp config directory with a config file
+function setupConfigFile(model: string): { configHome: string; cleanup: () => void } {
+  const configHome = Deno.makeTempDirSync();
+  const configDir = `${configHome}/git-commit-ai`;
+  Deno.mkdirSync(configDir, { recursive: true });
+  Deno.writeTextFileSync(
+    `${configDir}/config.json`,
+    JSON.stringify({ model }),
+  );
+  return {
+    configHome,
+    cleanup: () => {
+      try {
+        Deno.removeSync(configHome, { recursive: true });
+      } catch {
+        // ignore
+      }
+    },
+  };
+}
+
+Deno.test('env model: GIT_COMMIT_AI_MODEL is used when --model is not provided', async () => {
+  const originalEnv = Deno.env.get('GIT_COMMIT_AI_MODEL');
+  Deno.env.set('GIT_COMMIT_AI_MODEL', 'env-test-model');
+
+  const harness = createHarness();
+  harness.repo.stageFile('test.ts', '// test');
+  harness.ai.setResponse('feat: test');
+
+  const result = await harness.run({
+    dryRun: true,
+    noPush: true,
+  });
+  assertEquals(result.ok, true);
+
+  const [config] = capture(harness.ai.mock.generateCommitMessage).last();
+  assertEquals(config.model, 'env-test-model');
+
+  await harness.cleanup();
+
+  if (originalEnv === undefined) {
+    Deno.env.delete('GIT_COMMIT_AI_MODEL');
+  } else {
+    Deno.env.set('GIT_COMMIT_AI_MODEL', originalEnv);
+  }
+});
+
+Deno.test('env model: --model overrides GIT_COMMIT_AI_MODEL', async () => {
+  const originalEnv = Deno.env.get('GIT_COMMIT_AI_MODEL');
+  Deno.env.set('GIT_COMMIT_AI_MODEL', 'env-test-model');
+
+  const harness = createHarness();
+  harness.repo.stageFile('test.ts', '// test');
+  harness.ai.setResponse('feat: test');
+
+  const result = await harness.run({
+    model: 'cli-test-model',
+    dryRun: true,
+    noPush: true,
+  });
+  assertEquals(result.ok, true);
+
+  const [config] = capture(harness.ai.mock.generateCommitMessage).last();
+  assertEquals(config.model, 'cli-test-model');
+
+  await harness.cleanup();
+
+  if (originalEnv === undefined) {
+    Deno.env.delete('GIT_COMMIT_AI_MODEL');
+  } else {
+    Deno.env.set('GIT_COMMIT_AI_MODEL', originalEnv);
+  }
+});
+
+Deno.test('config file: model from config file is used when no --model or env var', async () => {
+  const originalXdg = Deno.env.get('XDG_CONFIG_HOME');
+  const originalEnv = Deno.env.get('GIT_COMMIT_AI_MODEL');
+
+  // Clear env var to ensure config file is used
+  Deno.env.delete('GIT_COMMIT_AI_MODEL');
+
+  // Setup config file
+  const { configHome, cleanup } = setupConfigFile('config-file-model');
+  Deno.env.set('XDG_CONFIG_HOME', configHome);
+
+  const harness = createHarness();
+  harness.repo.stageFile('test.ts', '// test');
+  harness.ai.setResponse('feat: test');
+
+  const result = await harness.run({
+    dryRun: true,
+    noPush: true,
+  });
+  assertEquals(result.ok, true);
+
+  const [config] = capture(harness.ai.mock.generateCommitMessage).last();
+  assertEquals(config.model, 'config-file-model');
+
+  await harness.cleanup();
+  cleanup();
+
+  // Restore env vars
+  if (originalXdg === undefined) {
+    Deno.env.delete('XDG_CONFIG_HOME');
+  } else {
+    Deno.env.set('XDG_CONFIG_HOME', originalXdg);
+  }
+  if (originalEnv === undefined) {
+    Deno.env.delete('GIT_COMMIT_AI_MODEL');
+  } else {
+    Deno.env.set('GIT_COMMIT_AI_MODEL', originalEnv);
+  }
+});
+
+Deno.test('config file: --model overrides config file model', async () => {
+  const originalXdg = Deno.env.get('XDG_CONFIG_HOME');
+  const originalEnv = Deno.env.get('GIT_COMMIT_AI_MODEL');
+
+  Deno.env.delete('GIT_COMMIT_AI_MODEL');
+
+  // Setup config file
+  const { configHome, cleanup } = setupConfigFile('config-file-model');
+  Deno.env.set('XDG_CONFIG_HOME', configHome);
+
+  const harness = createHarness();
+  harness.repo.stageFile('test.ts', '// test');
+  harness.ai.setResponse('feat: test');
+
+  const result = await harness.run({
+    model: 'cli-test-model',
+    dryRun: true,
+    noPush: true,
+  });
+  assertEquals(result.ok, true);
+
+  const [config] = capture(harness.ai.mock.generateCommitMessage).last();
+  assertEquals(config.model, 'cli-test-model');
+
+  await harness.cleanup();
+  cleanup();
+
+  // Restore env vars
+  if (originalXdg === undefined) {
+    Deno.env.delete('XDG_CONFIG_HOME');
+  } else {
+    Deno.env.set('XDG_CONFIG_HOME', originalXdg);
+  }
+  if (originalEnv === undefined) {
+    Deno.env.delete('GIT_COMMIT_AI_MODEL');
+  } else {
+    Deno.env.set('GIT_COMMIT_AI_MODEL', originalEnv);
+  }
+});
+
+Deno.test('config file: env var overrides config file model', async () => {
+  const originalXdg = Deno.env.get('XDG_CONFIG_HOME');
+  const originalEnv = Deno.env.get('GIT_COMMIT_AI_MODEL');
+
+  Deno.env.set('GIT_COMMIT_AI_MODEL', 'env-test-model');
+
+  // Setup config file
+  const { configHome, cleanup } = setupConfigFile('config-file-model');
+  Deno.env.set('XDG_CONFIG_HOME', configHome);
+
+  const harness = createHarness();
+  harness.repo.stageFile('test.ts', '// test');
+  harness.ai.setResponse('feat: test');
+
+  const result = await harness.run({
+    dryRun: true,
+    noPush: true,
+  });
+  assertEquals(result.ok, true);
+
+  const [config] = capture(harness.ai.mock.generateCommitMessage).last();
+  assertEquals(config.model, 'env-test-model');
+
+  await harness.cleanup();
+  cleanup();
+
+  // Restore env vars
+  if (originalXdg === undefined) {
+    Deno.env.delete('XDG_CONFIG_HOME');
+  } else {
+    Deno.env.set('XDG_CONFIG_HOME', originalXdg);
+  }
+  if (originalEnv === undefined) {
+    Deno.env.delete('GIT_COMMIT_AI_MODEL');
+  } else {
+    Deno.env.set('GIT_COMMIT_AI_MODEL', originalEnv);
+  }
+});


### PR DESCRIPTION
## Summary

- Fix `GIT_COMMIT_AI_MODEL` environment variable being ignored during model validation
- Add config file model loading in `handleGenerate` (was passing `undefined` before)
- Implement model resolution priority: CLI > env var > config file > default
- Add regression tests for all model resolution paths

## Changes

- `src/cmd/generate.ts`: Import `loadConfig`, load config file before computing `aiConfig`, pass loaded config to `mergeConfig`
- `tests/integration/generate-tests/env-model.test.ts`: New test file with 5 tests covering all resolution paths

## Model Resolution Priority

1. `--model` CLI flag (highest)
2. `GIT_COMMIT_AI_MODEL` environment variable
3. `model` field in config file (`~/.config/git-commit-ai/config.json`)
4. Built-in default model (lowest)

## Test plan

- [x] `GIT_COMMIT_AI_MODEL=provider/model git-commit-ai generate` succeeds without `--model`
- [x] `--model` CLI flag overrides `GIT_COMMIT_AI_MODEL` env var
- [x] `--model` CLI flag overrides config file `model` field
- [x] `GIT_COMMIT_AI_MODEL` env var overrides config file `model` field
- [x] Config file `model` field works when neither CLI flag nor env var is set
- [x] All 51 existing tests pass
- [x] Lint and type check pass

🤖 Generated with [Qoder](https://qoder.com)